### PR TITLE
添加 rehype 插件以增强表格 UI 控制能力

### DIFF
--- a/src/core/plugin/rehypeWrapTableCell.ts
+++ b/src/core/plugin/rehypeWrapTableCell.ts
@@ -1,0 +1,56 @@
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+type Element = {
+  type: "element";
+  tagName: string;
+  properties?: Record<string, any>;
+  children: any[];
+};
+
+function isElement(node: any): node is Element {
+  return (
+    node &&
+    node.type === "element" &&
+    typeof node.tagName === "string" &&
+    Array.isArray(node.children)
+  );
+}
+
+export const rehypeWrapTableCell: Plugin<[{ className?: string }?]> = (
+  options
+) => {
+  const className = options?.className ?? "custom-td-th-content-wrap";
+
+  return (tree: any) => {
+    visit(tree, "element", (node: any) => {
+      if (!isElement(node)) return;
+      if (node.tagName !== "td" && node.tagName !== "th") return;
+      if (!node.children || node.children.length === 0) return;
+
+      // 只处理th、td元素
+      // 避免重复包裹：如果th、td的第一个子元素span已经是我们标注的带有指定class的span，则跳过
+      if (
+        node.children.length === 1 &&
+        isElement(node.children[0]) &&
+        node.children[0].tagName === "span"
+      ) {
+        const first = node.children[0] as Element;
+        const cls = first.properties?.className;
+        const has = Array.isArray(cls)
+          ? cls.includes(className)
+          : cls === className;
+        if (has) return;
+      }
+
+      const wrapped: Element = {
+        type: "element",
+        tagName: "span",
+        properties: { className: [className] },
+        children: node.children,
+      };
+
+      node.children = [wrapped];
+    });
+  };
+};

--- a/src/core/plugin/rehypeWrapTables.ts
+++ b/src/core/plugin/rehypeWrapTables.ts
@@ -1,0 +1,54 @@
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+type Element = {
+  type: "element";
+  tagName: string;
+  properties?: Record<string, any>;
+  children: any[];
+};
+
+function isElement(node: any): node is Element {
+  return (
+    node &&
+    node.type === "element" &&
+    typeof node.tagName === "string" &&
+    Array.isArray(node.children)
+  );
+}
+
+export const rehypeWrapTables: Plugin<[{ className?: string }?]> = (
+  options
+) => {
+  const className = options?.className ?? "custom-table-wrapper";
+
+  return (tree: any) => {
+    visit(
+      tree,
+      "element",
+      (node: any, index: number | undefined | null, parent: any) => {
+        if (!parent || index == null) return;
+        if (!isElement(node)) return;
+        if (node.tagName !== "table") return;
+        // 只处理table元素
+        // 避免重复包裹：如果table的父元素已经被我们标注的带有指定class的div包裹，则跳过
+        if (isElement(parent) && parent.tagName === "div") {
+          const cls = parent.properties?.className;
+          const has = Array.isArray(cls)
+            ? cls.includes(className)
+            : cls === className;
+          if (has) return;
+        }
+
+        const wrapper: Element = {
+          type: "element",
+          tagName: "div",
+          properties: { className: [className] },
+          children: [node],
+        };
+
+        parent.children[index] = wrapper;
+      }
+    );
+  };
+};


### PR DESCRIPTION
# 问题背景
当 Markdown 渲染为 HTML 时，表格直接作为父容器的子元素。这导致了以下 UI 控制限制：
  1. 表格溢出控制问题：如果父容器设置了 overflow: hidden，当表格内容超出容器宽度时，无法实现独立的横向滚动。列宽限制和横向滚动条无法正确应用于作为直接子元素的`<table>`。
  2. 单元格内容控制问题：`<th>/<td> `元素内的内容 CSS 样式控制能力有限。文本截断省略号、最大宽度限制下的换行、单行显示溢出处理等功能难以实现。

# 解决方案
  新增两个 rehype 插件：
  rehypeWrapTables - 为每个 `<table>` 包裹一层 `<div class="custom-table-wrapper">`
  - 支持宽表格独立横向滚动
  - 实现溢出控制而不影响父容器
  - 类名可通过配置项自定义
 
  rehypeWrapTableCell - 为 `<th>/<td>` 内的内容包裹一层 `<span class="custom-td-th-content-wrap">`
  - 支持文本溢出省略号效果
  - 支持最大宽度限制下的文本换行
  - 提供更好的单元格内容样式控制
  - 类名可通过配置项自定义
## CSS 使用示例
```css
  /* 表格容器横向滚动 */
  .custom-table-wrapper {
    overflow-x: auto;
    max-width: 100%;
  }

  /* 单元格内容省略号效果 */
  .custom-td-th-content-wrap {
    display: inline-block;
    max-width: 200px;
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
  }
```
# 实现说明
  - 两个插件都包含防重复包裹逻辑，避免重复渲染时产生嵌套包裹
  - 类名可通过插件配置项自定义
  - 最小化 DOM 改动，仅添加必要的包裹元素
  - 此方案也被腾讯元宝采用，用于类似的表格渲染场景
  - 实际开发我遇到了这种需求，我已这种方式解决了，希望能够给当前项目做出一些贡献