### PR TITLE
feat: add remark plugin to improve table rendering in streaming responses

### DIFF
--- a/src/core/plugin/remarkTable.ts
+++ b/src/core/plugin/remarkTable.ts
@@ -1,0 +1,41 @@
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+export const remarkCompleteTable: Plugin = () => {
+  return (tree: any) => {
+    visit(tree, "paragraph", (node, index, parent) => {
+      const text = node.children
+        .filter((c) => c.type === "text")
+        .map((c) => c.value)
+        .join("");
+      const lines = text.split("\n");
+      // 行首符合| xxx |的语法
+      if (/^\|.+\|/.test(lines[0])) {
+        // 构建table节点
+        const rows = lines
+          .filter((l) => !/^\|[\s|:-]+\|?$/.test(l)) // 去掉分隔行
+          .map((line) => {
+            return {
+              type: "tableRow",
+              children: line
+                .split("|")
+                .slice(1, -1)
+                .map((c) => ({
+                  type: "tableCell",
+                  children: [
+                    {
+                      type: "text",
+                      value: c.trim(),
+                    },
+                  ],
+                })),
+            };
+          });
+        parent.children.splice(index, 1, {
+          type: "table",
+          children: rows,
+        });
+      }
+    });
+  };
+};


### PR DESCRIPTION

# Background
In streaming response scenarios, even if the speed is very fast, for complex tables with many columns, if the received content is incomplete and the syntax is not fully closed, it can result in a partially rendered output.
<img width="1792" height="906" alt="Image" src="https://github.com/user-attachments/assets/dc13b019-75d1-4e10-8922-7a8a2f3c8637" />
# Solution
So far, I’ve thought of two approaches. One is to cache incomplete syntax and only insert it into the Markdown text to be rendered once it becomes complete. The other is to create a custom `remark` plugin that recognizes segments like `| xx |` as tables in advance. Compared with the first approach, the second does not require caching and can display the content immediately without waiting for a certain amount of time.
## Implementation
Similar to this [MR](https://github.com/linzhe141/vue-markdown-renderer/pull/8), Use `visit` to traverse the entire mdast, and for each `paragraph` node, use a regular expression to check whether the beginning of the line matches a pattern like `| xx |`, then construct a `table` node to replace the original `paragraph` node.
# Benefits
When the content matches the table syntax prefix, it is rendered immediately, preventing incomplete table syntax from being displayed.
<img width="1828" height="790" alt="Image" src="https://github.com/user-attachments/assets/a5d833d3-aa2a-49ea-a195-c775ba62e78e" />

I’ve put the Markdown text [hear](https://stackblitz.com/edit/vitejs-vite-w82myuz8?file=public%2Fmd.md), you can give it a try.


Finally, I’d like to say that I’d be very happy to contribute to this project and look forward to your reply.